### PR TITLE
Make Whammy accessible from other include files.

### DIFF
--- a/whammy.js
+++ b/whammy.js
@@ -5,7 +5,7 @@
 */
 
 
-var Whammy = (function(){
+window.Whammy = (function(){
 	// in this case, frames has a very specific meaning, which will be 
 	// detailed once i finish writing the code
 


### PR DESCRIPTION
Using http://requirejs.org/  include Whammy will cause the Whammy function to be unavailable with `var`. In this format it is more compatible.
