### PR TITLE
Allow dataURL strings to be added directly

### DIFF
--- a/whammy.js
+++ b/whammy.js
@@ -427,12 +427,17 @@ window.Whammy = (function(){
 	WhammyVideo.prototype.add = function(frame, duration){
 		if(typeof duration != 'undefined' && this.duration) throw "you can't pass a duration if the fps is set";
 		if(typeof duration == 'undefined' && !this.duration) throw "if you don't have the fps set, you ned to have durations here."
-		if('canvas' in frame){ //CanvasRenderingContext2D
-			frame = frame.canvas;
+
+		if(typeof frame == 'object') {
+			if('canvas' in frame){ //CanvasRenderingContext2D
+				frame = frame.canvas;
+			}
+			if('toDataURL' in frame){
+				frame = frame.toDataURL('image/webp', this.quality)
+			}
 		}
-		if('toDataURL' in frame){
-			frame = frame.toDataURL('image/webp', this.quality)
-		}else if(typeof frame != "string"){
+
+		if(typeof frame != "string"){
 			throw "frame must be a a HTMLCanvasElement, a CanvasRenderingContext2D or a DataURI formatted string"
 		}
 		if (!(/^data:image\/webp;base64,/ig).test(frame)) {


### PR DESCRIPTION
Based on the code and documentation, it looks like Whammy is suppose to be able to support directly adding dataURL in the form of image/webp. However the add function tries to use the "in" operator to check for the existence of a property on the frame variable, which is not useable in strings.
