### PR TITLE
Fix length parsing for WEBP chunk.

### DIFF
--- a/whammy.js
+++ b/whammy.js
@@ -448,18 +448,21 @@ window.Whammy = (function(){
 
 		while (offset < string.length) {
 			var id = string.substr(offset, 4);
-			var len = parseInt(string.substr(offset + 4, 4).split('').map(function(i){
-				var unpadded = i.charCodeAt(0).toString(2);
-				return (new Array(8 - unpadded.length + 1)).join('0') + unpadded
-			}).join(''),2);
-			var data = string.substr(offset + 4 + 4, len);
-			offset += 4 + 4 + len;
 			chunks[id] = chunks[id] || [];
-
 			if (id == 'RIFF' || id == 'LIST') {
+				var len = parseInt(string.substr(offset + 4, 4).split('').map(function(i){
+					var unpadded = i.charCodeAt(0).toString(2);
+					return (new Array(8 - unpadded.length + 1)).join('0') + unpadded
+				}).join(''),2);
+				var data = string.substr(offset + 4 + 4, len);
+				offset += 4 + 4 + len;
 				chunks[id].push(parseRIFF(data));
+			} else if (id == 'WEBP') {
+				// Use (offset + 8) to skip past "VP8 "/"VP8L"/"VP8X" field after "WEBP"
+				chunks[id].push(string.substr(offset + 8));
 			} else {
-				chunks[id].push(data);
+				// Unknown chunk type; push entire payload
+				chunks[id].push(string.substr(offset + 4));
 			}
 		}
 		return chunks;


### PR DESCRIPTION
Currently, the length of the WEBP payload is assumed to be written
according to RIFF file format (i.e., the four bytes immediately
after the ID field).  That's not correct:

https://developers.google.com/speed/webp/docs/riff_container#webp_file_header

The length of the WEBP payload is the entire rest of the RIFF file.
This probably hasn't been breaking anything because the value which
is used (incorrectly) to determine the length is the fixed string
"VP8 ", which decodes to a very large number (1448097824, to be
exact).  So, this line:

var data = string.substr(offset + 4 + 4, len);

... will always get the entire rest of the file, unless the image is
REALLY REALLY big.