### PR TITLE
Deferred webp encoding for faster frame add

### DIFF
--- a/clock.html
+++ b/clock.html
@@ -139,15 +139,17 @@ function nextFrame(){
 
 function finalizeVideo(){
 	var start_time = +new Date;
-	var output = video.compile();
-	var end_time = +new Date;
-	var url = webkitURL.createObjectURL(output);
+	video.compile(false, function(output){
 
-	document.getElementById('awesome').src = url; //toString converts it to a URL via Object URLs, falling back to DataURL
-	document.getElementById('download').style.display = '';
-	document.getElementById('download').href = url;
-	document.getElementById('status').innerHTML = "Compiled Video in " + (end_time - start_time) + "ms, file size: " + Math.ceil(output.size / 1024) + "KB";
+		var end_time = +new Date;
+		var url = webkitURL.createObjectURL(output);
 
+		document.getElementById('awesome').src = url; //toString converts it to a URL via Object URLs, falling back to DataURL
+		document.getElementById('download').style.display = '';
+		document.getElementById('download').href = url;
+		document.getElementById('status').innerHTML = "Compiled Video in " + (end_time - start_time) + "ms, file size: " + Math.ceil(output.size / 1024) + "KB";
+
+	});
 }
 
 nextFrame();


### PR DESCRIPTION
Storing image data is much faster than encoding to webp. This PR stores the image data, and waits to encode webp in the compile method.

Here are some test videos from #34 

Immediate encoding: https://youtu.be/QK9AOAvGMsw

Delayed encoding: https://youtu.be/99Kob5Xv0Yk