### PR TITLE
properly remove webp metadata (fixes #43)

### DIFF
--- a/whammy.js
+++ b/whammy.js
@@ -189,7 +189,7 @@ window.Whammy = (function(){
 					].concat(clusterFrames.map(function(webp){
 						var block = makeSimpleBlock({
 							discardable: 0,
-							frame: webp.data.slice(4),
+							frame: webp.data.slice(webp.data.indexOf('\x9d\x01\x2a') - 3),
 							invisible: 0,
 							keyframe: 1,
 							lacing: 0,


### PR DESCRIPTION
A Chrome update added metadata to generated WebP, which caused videos generated by Whammy to be invalid.

@chrahunt [describes the fix](https://github.com/chrahunt/TagProReplays/issues/78#issuecomment-241214977):

> Okay, I figured out the issue. In Whammy [here](https://github.com/antimatter15/whammy/blob/a1c8e861a3269387ffac519fe6e96c645efb6686/whammy.js#L192) it skips the first 4 bytes of the VP8* chunk, assuming there's no additional metadata. Well now there is, but it isn't what the webp format is expecting. Replacing `4` with `webp.data.indexOf('\x9d\x01\x2a') - 3` did the trick (get to the `start_code` then back up 3 bytes for the `frame_tag` as detailed [here](https://tools.ietf.org/html/rfc6386#section-19.1). I did a local test and was able to generate a webm that ffmpeg approved of.